### PR TITLE
increase request timeout to dax

### DIFF
--- a/src/server/proxy-service.ts
+++ b/src/server/proxy-service.ts
@@ -130,7 +130,7 @@ export class ProxyService {
         headers: upstreamHeaders,
         params: request.query,
         data: contentToSend,
-        timeout: 90000, // 90 seconds
+        timeout: 3000000, // 5 minutes
         responseType: 'arraybuffer',
         validateStatus: () => true, // Don't throw on non-2xx status codes
       };


### PR DESCRIPTION
Sometimes dax took a while to finish but return-reminder client stopped waiting