### PR TITLE
[feat] use mcp tools instead of auth

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "axios": "^1.6.0",
         "dotenv": "^16.3.1",
         "express": "^5.1.0",
+        "express-session": "^1.18.2",
         "http-proxy-middleware": "^3.0.5",
         "lightningcss": "^1.30.1",
         "prettier": "^3.5.3",
@@ -31,6 +32,7 @@
       "devDependencies": {
         "@eslint/js": "^9.25.0",
         "@types/express": "^5.0.1",
+        "@types/express-session": "^1.18.2",
         "@types/node": "^22.15.2",
         "@types/react": "^19.1.2",
         "@types/react-dom": "^19.1.2",
@@ -1937,6 +1939,16 @@
         "@types/send": "*"
       }
     },
+    "node_modules/@types/express-session": {
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/@types/express-session/-/express-session-1.18.2.tgz",
+      "integrity": "sha512-k+I0BxwVXsnEU2hV77cCobC08kIsn4y44C3gC0b46uxZVMaXA04lSPgRLR/bSL2w0t0ShJiG8o4jPzRG/nscFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*"
+      }
+    },
     "node_modules/@types/http-errors": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
@@ -3277,6 +3289,46 @@
         "express": ">= 4.11"
       }
     },
+    "node_modules/express-session": {
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.18.2.tgz",
+      "integrity": "sha512-SZjssGQC7TzTs9rpPDuUrR23GNZ9+2+IkA/+IJWmvQilTr5OSliEHGF+D9scbIpdC6yGtTI0/VhaHoVes2AN/A==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.7",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-headers": "~1.1.0",
+        "parseurl": "~1.3.3",
+        "safe-buffer": "5.2.1",
+        "uid-safe": "~2.1.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/express-session/node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/express-session/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/express-session/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
     "node_modules/express-static-gzip": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/express-static-gzip/-/express-static-gzip-2.2.0.tgz",
@@ -4585,6 +4637,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/on-headers": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -4835,6 +4896,15 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/random-bytes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
+      "integrity": "sha512-iv7LhNVO047HzYR3InF6pUcUsPQiHTM1Qal51DcGSuZFBil1aBBWG5eHPNek7bvILMaYJ/8RU1e8w1AMdHmLQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
@@ -5519,6 +5589,18 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/uid-safe": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
+      "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
+      "license": "MIT",
+      "dependencies": {
+        "random-bytes": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/undefsafe": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@headlessui/react": "^2.2.4",
         "@maxmind/geoip2-node": "^6.1.0",
+        "@modelcontextprotocol/sdk": "^1.17.5",
         "@tailwindcss/forms": "^0.5.10",
         "@tailwindcss/vite": "^4.1.10",
         "axios": "^1.6.0",
@@ -1096,6 +1097,29 @@
       "license": "Apache-2.0",
       "dependencies": {
         "maxmind": "^4.2.0"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.17.5",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.17.5.tgz",
+      "integrity": "sha512-QakrKIGniGuRVfWBdMsDea/dx1PNE739QJ7gCM41s9q+qaCYTHCdsIBXQVVXry3mfWAiaM9kT22Hyz53Uw8mfg==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.6",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.0.1",
+        "express-rate-limit": "^7.5.0",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.23.8",
+        "zod-to-json-schema": "^3.24.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -2323,7 +2347,6 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -2714,11 +2737,23 @@
         "node": ">=6.6.0"
       }
     },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -3164,6 +3199,27 @@
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "license": "MIT"
     },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/express": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
@@ -3204,6 +3260,21 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
+      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
       }
     },
     "node_modules/express-static-gzip": {
@@ -3300,8 +3371,7 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -3322,8 +3392,7 @@
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
@@ -3856,8 +3925,7 @@
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
     "node_modules/jiti": {
       "version": "2.4.2",
@@ -3909,8 +3977,7 @@
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -4485,6 +4552,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -4599,7 +4675,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -4629,6 +4704,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.0.tgz",
+      "integrity": "sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/postcss": {
@@ -4713,7 +4797,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -5054,7 +5137,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -5066,7 +5148,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -5497,7 +5578,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -5634,7 +5714,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -5677,6 +5756,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.24.6",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.6.tgz",
+      "integrity": "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.24.1"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@headlessui/react": "^2.2.4",
     "@maxmind/geoip2-node": "^6.1.0",
+    "@modelcontextprotocol/sdk": "^1.17.5",
     "@tailwindcss/forms": "^0.5.10",
     "@tailwindcss/vite": "^4.1.10",
     "axios": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "axios": "^1.6.0",
     "dotenv": "^16.3.1",
     "express": "^5.1.0",
+    "express-session": "^1.18.2",
     "http-proxy-middleware": "^3.0.5",
     "lightningcss": "^1.30.1",
     "prettier": "^3.5.3",
@@ -34,6 +35,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",
+    "@types/express-session": "^1.18.2",
     "@types/express": "^5.0.1",
     "@types/node": "^22.15.2",
     "@types/react": "^19.1.2",

--- a/src/client/config/amazon.json
+++ b/src/client/config/amazon.json
@@ -4,7 +4,7 @@
   "logo_url": "https://i.pinimg.com/originals/01/ca/da/01cada77a0a7d326d85b7969fe26a728.jpg",
   "is_mandatory": true,
   "dataTransform": {
-    "dataPath": "bundles.1.content",
+    "dataPath": "extract_result.0.content",
     "fieldMappings": [
       {
         "outputKey": "brand",

--- a/src/client/config/amazonca.json
+++ b/src/client/config/amazonca.json
@@ -4,7 +4,7 @@
   "logo_url": "https://i.pinimg.com/originals/01/ca/da/01cada77a0a7d326d85b7969fe26a728.jpg",
   "is_mandatory": false,
   "dataTransform": {
-    "dataPath": "bundles.1.content",
+    "dataPath": "extract_result.0.content",
     "fieldMappings": [
       {
         "outputKey": "brand",

--- a/src/client/config/officedepot.json
+++ b/src/client/config/officedepot.json
@@ -3,7 +3,7 @@
   "brand_name": "Office Depot",
   "logo_url": "https://upload.wikimedia.org/wikipedia/commons/e/e3/Office-depot-logo.png",
   "dataTransform": {
-    "dataPath": "bundles.1.content",
+    "dataPath": "extract_result.0.content",
     "fieldMappings": [
       {
         "outputKey": "brand",

--- a/src/client/config/wayfair.json
+++ b/src/client/config/wayfair.json
@@ -3,7 +3,7 @@
   "brand_name": "Wayfair",
   "logo_url": "https://upload.wikimedia.org/wikipedia/commons/0/0a/Wayfair_logo_with_tagline.png",
   "dataTransform": {
-    "dataPath": "bundles.0.content.data.orderProductPagesByCustomer.nodes",
+    "dataPath": "extract_result.0.content.data.orderProductPagesByCustomer.nodes",
     "fieldMappings": [
       {
         "outputKey": "brand",

--- a/src/server/main.ts
+++ b/src/server/main.ts
@@ -180,35 +180,31 @@ app.use('/getgather', async (req, res) => {
   await proxyService.reverseProxy(req, res, fullPath);
 });
 
-async function startServer() {
-  try {
-    console.log('Checking GETGATHER_URL:', settings.GETGATHER_URL);
-    const response = await fetch(settings.GETGATHER_URL);
-    if (response.status === 200) {
-      console.log('✓ GETGATHER_URL is reachable');
-    } else {
-      console.warn(`⚠ GETGATHER_URL returned status ${response.status}`);
-    }
-  } catch (error) {
-    console.error(
-      '✗ GETGATHER_URL is not reachable:',
-      error instanceof Error ? error.message : String(error)
-    );
-  }
-
-  if (settings.NODE_ENV === 'development') {
-    ViteExpress.listen(app, 3000, () =>
-      console.log('Server is listening on port http://localhost:3000')
-    );
+try {
+  console.log('Checking GETGATHER_URL:', settings.GETGATHER_URL);
+  const response = await fetch(settings.GETGATHER_URL);
+  if (response.status === 200) {
+    console.log('✓ GETGATHER_URL is reachable');
   } else {
-    app.use(express.static(path.join(__dirname, 'dist')));
-    app.get('*name', (req, res) => {
-      res.sendFile(path.join(__dirname, 'dist', 'index.html'));
-    });
-    app.listen(3000, () => {
-      console.log('Server is running at http://localhost:3000');
-    });
+    console.warn(`⚠ GETGATHER_URL returned status ${response.status}`);
   }
+} catch (error) {
+  console.error(
+    '✗ GETGATHER_URL is not reachable:',
+    error instanceof Error ? error.message : String(error)
+  );
 }
 
-startServer();
+if (settings.NODE_ENV === 'development') {
+  ViteExpress.listen(app, 3000, () =>
+    console.log('Server is listening on port http://localhost:3000')
+  );
+} else {
+  app.use(express.static(path.join(__dirname, 'dist')));
+  app.get('*name', (req, res) => {
+    res.sendFile(path.join(__dirname, 'dist', 'index.html'));
+  });
+  app.listen(3000, () => {
+    console.log('Server is running at http://localhost:3000');
+  });
+}

--- a/src/server/main.ts
+++ b/src/server/main.ts
@@ -61,7 +61,7 @@ app.use(
     resave: false,
     saveUninitialized: false,
     cookie: {
-      secure: process.env.NODE_ENV == 'production',
+      secure: settings.NODE_ENV === 'production',
       httpOnly: true,
       maxAge: 24 * 60 * 60 * 1000, // 24 hours
     },
@@ -195,11 +195,8 @@ try {
   );
 }
 
-if (settings.NODE_ENV === 'development') {
-  ViteExpress.listen(app, 3000, () =>
-    console.log('Server is listening on port http://localhost:3000')
-  );
-} else {
+if (settings.NODE_ENV === 'production') {
+  app.set('trust proxy', 1);
   app.use(express.static(path.join(__dirname, 'dist')));
   app.get('*name', (req, res) => {
     res.sendFile(path.join(__dirname, 'dist', 'index.html'));
@@ -207,4 +204,8 @@ if (settings.NODE_ENV === 'development') {
   app.listen(3000, () => {
     console.log('Server is running at http://localhost:3000');
   });
+} else {
+  ViteExpress.listen(app, 3000, () =>
+    console.log('Server is listening on port http://localhost:3000')
+  );
 }

--- a/src/server/mcp-service.ts
+++ b/src/server/mcp-service.ts
@@ -1,0 +1,122 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { settings } from './config.js';
+
+const BRAND_MCP_TOOLS: Record<string, string> = {
+  amazon: 'amazon_get_purchase_history',
+  amazonca: 'amazonca_get_purchase_history',
+  officedepot: 'officedepot_get_order_history',
+  wayfair: 'wayfair_get_order_history',
+};
+
+export class MCPService {
+  private static instance: MCPService | null = null;
+  private client: Client | null = null;
+  private initPromise: Promise<Client> | null = null;
+  private serverUrl: string;
+  private mcpUrl: string;
+
+  private constructor() {
+    this.serverUrl = settings.GETGATHER_URL || 'http://localhost:8000';
+    this.mcpUrl = `${this.serverUrl}/mcp/`;
+  }
+
+  static getInstance(): MCPService {
+    if (!MCPService.instance) {
+      MCPService.instance = new MCPService();
+    }
+    return MCPService.instance;
+  }
+
+  private async initializeClient(): Promise<Client> {
+    if (this.client) return this.client;
+    if (this.initPromise) return this.initPromise;
+
+    this.initPromise = (async () => {
+      const client = new Client(
+        { name: 'return-reminder-server', version: '1.0.0' },
+        { capabilities: {} }
+      );
+
+      const transport = new StreamableHTTPClientTransport(new URL(this.mcpUrl));
+      await client.connect(transport);
+
+      this.client = client;
+      console.log('MCP client initialized successfully');
+      return client;
+    })();
+
+    try {
+      return await this.initPromise;
+    } finally {
+      this.initPromise = null;
+    }
+  }
+
+  async getClient(): Promise<Client> {
+    if (!this.client) {
+      await this.initializeClient();
+    }
+    if (!this.client) {
+      throw new Error('MCP client initialization failed');
+    }
+    return this.client;
+  }
+
+  getMCPToolName(brandId: string): string {
+    const toolName = BRAND_MCP_TOOLS[brandId];
+    if (!toolName) {
+      throw new Error(`No MCP tool configured for brand: ${brandId}`);
+    }
+    return toolName;
+  }
+
+  async retrieveData(brandId: string) {
+    const client = await this.getClient();
+    const toolName = this.getMCPToolName(brandId);
+
+    console.log(`Calling MCP tool: ${toolName} for brand: ${brandId}`);
+
+    try {
+      const result = await client.callTool({
+        name: toolName,
+        arguments: {},
+      });
+
+      console.log(
+        `MCP tool response for ${brandId}:`,
+        JSON.stringify(result.structuredContent, null, 2)
+      );
+      return result.structuredContent;
+    } catch (error) {
+      console.error(`Error calling MCP tool ${toolName}:`, error);
+      throw error;
+    }
+  }
+
+  async pollAuth(linkId: string) {
+    const client = await this.getClient();
+
+    console.log(`Polling auth status for link_id: ${linkId}`);
+
+    const result = await client.callTool(
+      {
+        name: 'poll_auth',
+        arguments: { link_id: linkId },
+      },
+      undefined,
+      {
+        timeout: 6000000,
+        maxTotalTimeout: 6000000,
+      }
+    );
+
+    return result.structuredContent;
+  }
+
+  getServerUrl(): string {
+    return this.serverUrl;
+  }
+}
+
+export const mcpService = MCPService.getInstance();


### PR DESCRIPTION
Use mcp tools instead of getgather api to extract the data

Tests:
- amazon login
https://github.com/user-attachments/assets/4369dd4d-ad23-4d09-bd7f-c99eaf4977fa

- wayfair logged in, only extracting
https://github.com/user-attachments/assets/448b2b03-5ec9-4c7f-bfe2-10fda7ba5037

- reconnecting mcp
```
Retrieve data request for brand_id: amazon
Calling MCP tool: amazon_get_purchase_history for brand: amazon
callTool failed, reconnecting with MCP Client... Error: Error POSTing to endpoint (HTTP 400): Bad Request: No valid session ID provided
```

