### PR TITLE
feat: support amazon new response from mcp

### DIFF
--- a/src/client/config/amazon.json
+++ b/src/client/config/amazon.json
@@ -4,7 +4,7 @@
   "logo_url": "https://i.pinimg.com/originals/01/ca/da/01cada77a0a7d326d85b7969fe26a728.jpg",
   "is_mandatory": true,
   "dataTransform": {
-    "dataPath": "extract_result.0.content",
+    "dataPath": ["purchases", "extract_result.0.content"],
     "fieldMappings": [
       {
         "outputKey": "brand",

--- a/src/client/config/amazon.json
+++ b/src/client/config/amazon.json
@@ -4,7 +4,7 @@
   "logo_url": "https://i.pinimg.com/originals/01/ca/da/01cada77a0a7d326d85b7969fe26a728.jpg",
   "is_mandatory": true,
   "dataTransform": {
-    "dataPath": ["purchases", "extract_result.0.content"],
+    "dataPath": "purchases",
     "fieldMappings": [
       {
         "outputKey": "brand",

--- a/src/client/config/amazonca.json
+++ b/src/client/config/amazonca.json
@@ -4,7 +4,7 @@
   "logo_url": "https://i.pinimg.com/originals/01/ca/da/01cada77a0a7d326d85b7969fe26a728.jpg",
   "is_mandatory": false,
   "dataTransform": {
-    "dataPath": "extract_result.0.content",
+    "dataPath": "purchases",
     "fieldMappings": [
       {
         "outputKey": "brand",

--- a/src/client/modules/DataTransformSchema.ts
+++ b/src/client/modules/DataTransformSchema.ts
@@ -23,8 +23,8 @@ export type DataFieldMapping = {
 };
 
 export type DataTransformSchema = {
-  /** JSONPath to the array of items to transform - can be string or array of fallback paths */
-  dataPath: string | string[];
+  /** JSONPath to the array of items to transform */
+  dataPath: string;
   /** Field mappings for transformation */
   fieldMappings: DataFieldMapping[];
 };
@@ -167,20 +167,11 @@ export function transformData(
     // Determine where the data array is located.
     let dataArray: unknown;
 
-    const dataPaths = Array.isArray(schema.dataPath)
-      ? schema.dataPath
-      : [schema.dataPath];
-
-    for (const path of dataPaths) {
-      if (path && path.trim() !== '') {
-        dataArray = getNestedValue(rawData, path);
-        if (Array.isArray(dataArray)) {
-          break;
-        }
-      }
+    if (schema.dataPath && schema.dataPath.trim() !== '') {
+      dataArray = getNestedValue(rawData, schema.dataPath);
     }
 
-    // Fallback: if no dataPath resolved, but the rawData itself is an array, use it.
+    // Fallback: if dataPath is empty or did not resolve, but the rawData itself is an array, use it.
     if (!Array.isArray(dataArray) && Array.isArray(rawData)) {
       dataArray = rawData;
     }

--- a/src/client/modules/DataTransformSchema.ts
+++ b/src/client/modules/DataTransformSchema.ts
@@ -23,8 +23,8 @@ export type DataFieldMapping = {
 };
 
 export type DataTransformSchema = {
-  /** JSONPath to the array of items to transform */
-  dataPath: string;
+  /** JSONPath to the array of items to transform - can be string or array of fallback paths */
+  dataPath: string | string[];
   /** Field mappings for transformation */
   fieldMappings: DataFieldMapping[];
 };
@@ -167,11 +167,20 @@ export function transformData(
     // Determine where the data array is located.
     let dataArray: unknown;
 
-    if (schema.dataPath && schema.dataPath.trim() !== '') {
-      dataArray = getNestedValue(rawData, schema.dataPath);
+    const dataPaths = Array.isArray(schema.dataPath)
+      ? schema.dataPath
+      : [schema.dataPath];
+
+    for (const path of dataPaths) {
+      if (path && path.trim() !== '') {
+        dataArray = getNestedValue(rawData, path);
+        if (Array.isArray(dataArray)) {
+          break;
+        }
+      }
     }
 
-    // Fallback: if dataPath is empty or did not resolve, but the rawData itself is an array, use it.
+    // Fallback: if no dataPath resolved, but the rawData itself is an array, use it.
     if (!Array.isArray(dataArray) && Array.isArray(rawData)) {
       dataArray = rawData;
     }


### PR DESCRIPTION
## Summary

  Updated the dataPath configuration to support an array of fallback paths for more flexible data extraction. 
  This allows the system to try multiple JSONPath expressions when extracting data from different response 
  structures.

  ## Changes

  - Modified \`DataTransformSchema.ts\` to support \`dataPath\` as either a string or array of strings
  - Updated the \`transformData\` function to iterate through multiple paths and use the first one that 
  resolves to an array
  - Updated Amazon configuration to use an array of fallback paths: \`[\"purchases\", 
  \"extract_result.0.content\"]\`
  - Added proper type definitions and documentation for the new array support

  ## Additional Notes

  This change maintains backward compatibility with existing string-based dataPath configurations while adding
   support for fallback paths. The system will try each path in order until it finds one that resolves to a 
  valid array, providing more robust data extraction capabilities.

https://github.com/user-attachments/assets/dd167a0f-c6e6-4a54-af73-1e8ea215b794


