### PR TITLE
fix: sync container location between local dev and docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,6 @@ COPY --from=docker.io/tailscale/tailscale:stable /usr/local/bin/tailscale /app/t
 RUN mkdir -p /var/run/tailscale /var/cache/tailscale /var/lib/tailscale
 
 COPY --from=builder /app/src/server ./src/server
-COPY --from=builder /app/dist ./src/server/dist
 COPY --from=builder /app/package.json ./package.json
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/src/client/config ./src/client/config

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,4 +8,8 @@ export default defineConfig({
   server: {
     allowedHosts: true,
   },
+  build: {
+    outDir: './src/server/dist',
+    emptyOutDir: true,
+  },
 });


### PR DESCRIPTION
Previously, when running npm run build and npm run start, the index.html file couldn’t be found. That happened because the expected location defined in main.ts was different from what the Docker setup and scripts were using.