### PR TITLE
Reintroduce 1 minimum machine for Fly deployment

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -13,7 +13,7 @@ primary_region = 'sjc'
   force_https = true
   auto_stop_machines = 'stop'
   auto_start_machines = true
-  min_machines_running = 0
+  min_machines_running = 1
   processes = ['app']
 
 [[vm]]


### PR DESCRIPTION
There is still a 5-second cold start with 0 minimum machine, so let's bump it to 1.