### PR TITLE
fix: remove --accept-routes flag from Tailscale setup

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -6,7 +6,7 @@ if [ -n "${TAILSCALE_AUTHKEY}" ]; then
     /app/tailscaled --state=/var/lib/tailscale/tailscaled.state --socket=/var/run/tailscale/tailscaled.sock &
 
     echo "Authenticating with Tailscale..."
-    /app/tailscale up --authkey="${TAILSCALE_AUTHKEY}" --hostname=return-reminder --accept-routes &
+    /app/tailscale up --authkey="${TAILSCALE_AUTHKEY}" --hostname=return-reminder &
 else
     echo "TAILSCALE_AUTHKEY not set, skipping Tailscale setup"
 fi


### PR DESCRIPTION
Remove the \`--accept-routes\` flag from the Tailscale setup command in the startup script to fix deployment issues on Fly.io.

