### PR TITLE
Migrate amazon dpage tools

### DIFF
--- a/src/client/config/amazonca.json
+++ b/src/client/config/amazonca.json
@@ -3,6 +3,7 @@
   "brand_name": "Amazon Canada",
   "logo_url": "https://i.pinimg.com/originals/01/ca/da/01cada77a0a7d326d85b7969fe26a728.jpg",
   "is_mandatory": false,
+  "is_dpage": true,
   "dataTransform": {
     "dataPath": "purchases",
     "fieldMappings": [

--- a/src/server/mcp-service.ts
+++ b/src/server/mcp-service.ts
@@ -16,7 +16,7 @@ type MCPTool = {
 
 const BRAND_MCP_TOOLS: Record<string, MCPTool[]> = {
   amazon: [{ name: 'amazon_dpage_get_purchase_history' }],
-  amazonca: [{ name: 'amazonca_get_purchase_history' }],
+  amazonca: [{ name: 'amazonca_dpage_get_purchase_history' }],
   officedepot: [
     { name: 'officedepot_get_order_history' },
     {


### PR DESCRIPTION
add config to use dpage for amazonca

Opening dpage sign in:
<img width="994" height="922" alt="CleanShot 2025-11-12 at 11 47 41@2x" src="https://github.com/user-attachments/assets/d9b84636-23ca-45a6-b4ea-4227fae61da6" />
Shows connected, but the account has 0 order:
<img width="1904" height="538" alt="CleanShot 2025-11-12 at 12 15 28@2x" src="https://github.com/user-attachments/assets/cde2a350-81b5-4f74-a397-4c6610ae081b" />

